### PR TITLE
ensure we are using the relevant command to start the service

### DIFF
--- a/lib/units/device/plugins/service.js
+++ b/lib/units/device/plugins/service.js
@@ -33,8 +33,9 @@ module.exports = syrup.serial()
   .dependency(require('../support/adb'))
   .dependency(require('../support/router'))
   .dependency(require('../support/push'))
+  .dependency(require('../support/sdk'))
   .dependency(require('../resources/service'))
-  .define(function(options, adb, router, push, apk) {
+  .define(function(options, adb, router, push, sdk, apk) {
     var log = logger.createLogger('device:plugins:service')
     var messageResolver = new MessageResolver()
     var plugin = new events.EventEmitter()
@@ -62,9 +63,11 @@ module.exports = syrup.serial()
     }
 
     function callService(intent) {
+      var startServiceCmd = (sdk.level < 26) ? 'startservice' : 'start-foreground-service'
+      log.info('using \'%s\' command for API %s', startServiceCmd, sdk.level)
       return adb.shell(options.serial, util.format(
-        'am startservice --user 0 %s'
-        , intent
+        'am %s --user 0 %s'
+        , startServiceCmd, intent
         ))
         .timeout(15000)
         .then(function(out) {
@@ -76,8 +79,8 @@ module.exports = syrup.serial()
             .then(function(line) {
               if (line.indexOf('--user') !== -1) {
                 return adb.shell(options.serial, util.format(
-                  'am startservice %s'
-                  , intent
+                  'am %s %s'
+                  , startServiceCmd, intent
                   ))
                   .timeout(15000)
                   .then(function() {


### PR DESCRIPTION
Android prevents the launch of a service if the app is in
background. This change is related to
https://github.com/openstf/STFService.apk/pull/38
which increased the targetSdkLevel of the STFService app.